### PR TITLE
Add bash for various Drush scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
     mysql-client \
     openssh \
     rsync \
+    bash \
   && { \
     echo 'memory_limit=-1'; \
   } > /usr/local/etc/php/php-cli.ini


### PR DESCRIPTION
This addresses issues where Drush can't run certain shell scripts (such as the one generated by `drush sql-dump`) due to missing Bash.